### PR TITLE
ADD: graphicsmagick devel package, prevent issue Image IO disabled du…

### DIFF
--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -25,6 +25,14 @@ conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 run_conda_forge_build_setup
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libXdamage libXfixes libXxf86vm libxcb libXft expat xorg-x11-proto GraphicsMagick-devel GraphicsMagick-c++-devel
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -31,7 +31,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libXdamage libXfixes libXxf86vm libxcb libXft expat xorg-x11-proto
+/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libXdamage libXfixes libXxf86vm libxcb libXft expat xorg-x11-proto GraphicsMagick-devel GraphicsMagick-c++-devel
 
 
 # make the build number clobber

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patch-qscintilla2.diff
 
 build:
-  number: 8
+  number: 9
   skip: True  # [win]
   features:
     - blas_{{ variant }}

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -8,3 +8,5 @@ libxcb
 libXft
 expat
 xorg-x11-proto
+GraphicsMagick-devel
+GraphicsMagick-c++-devel


### PR DESCRIPTION
…ring compilation for Octave
@conda-forge-admin, please rerender

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #18
<!--
Please add any other relevant info below:
-->
Adds GraphicMagick devel package into yum, so Octave is build with it's support.