### PR TITLE
Enable JSON read/write by adding RapidJSON dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,6 +84,7 @@ requirements:
     - fltk
     - libiconv
     - alsa-lib  # [linux]
+    - rapidjson
   run:
     - ghostscript
     - texinfo

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b12cb652587d31c5c382b39ed73463c22a5259ecb2fa6b323a27da409222dacc
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   binary_has_prefix_files:   # [unix]
     - bin/octave-{{ version }}  # [linux]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This allows use of `jsonencode`/`jsondecode`, which were introduced in [Octave 7.1](https://docs.octave.org/v7.1.0/JSON-data-encoding_002fdecoding.html). The `PrettyWriter` option will not work until a new version of RapidJSON is released (see issues in Octave's configure.ac [here](https://github.com/gnu-octave/octave/blob/0e1a0a9fba408459f84f5843b239dd2851e813d1/configure.ac#L1421)).
