### PR TITLE
Add run_exports section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   binary_has_prefix_files:   # [linux]
     - bin/octave-{{ version }}  # [linux]
   run_exports:
-    - {{ pin_subpackage('octave', max_pin='x.x') }}
+    - {{ pin_subpackage('octave', max_pin='x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,12 @@ source:
   sha256: b12cb652587d31c5c382b39ed73463c22a5259ecb2fa6b323a27da409222dacc
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
-  binary_has_prefix_files:   # [unix]
+  binary_has_prefix_files:   # [linux]
     - bin/octave-{{ version }}  # [linux]
+  run_exports:
+    - {{ pin_subpackage('octave', max_pin='x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
Adding a xeus-exports section. Octave 7 bumbed the soname, which broke downstream packages like xeus-octave.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
