### PR TITLE
Fix GraphicsMagick++ (closes #101)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,7 @@ fi
     --enable-dl \
     --without-qrupdate \
     --with-qt=5 \
-    --with-magick=GraphicsMagick \
+    --with-magick=GraphicsMagick++ \
     --without-framework-carbon \
     --with-hdf5-includedir=${PREFIX}/include \
     --with-hdf5-libdir=${PREFIX}/lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 0636554b05996997e431caad4422c00386d2d7c68900472700fecf5ffeb7c991
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   binary_has_prefix_files:   # [linux]
     - bin/octave-{{ version }}  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     - libsndfile
     - qscintilla2
     - qhull
-    - graphicsmagick  # [linux]
+    - graphicsmagick
     # Following gets linked at the end.
     - icu
     - ncurses
@@ -106,7 +106,7 @@ requirements:
     - libsndfile
     - {{ pin_compatible("qscintilla2", max_pin="x.x") }}
     - qhull
-    - {{ pin_compatible("graphicsmagick") }}   # [linux]
+    - {{ pin_compatible("graphicsmagick") }}
     # Following gets linked at the end.
     - icu
     - ncurses


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

This PR fixes `imread()` and `imwrite()` in Octave. However, the `graphicsmagick` package in `conda-forge` is still built with 8-bit depth, which will give a warning (see [Octave's docs](https://wiki.octave.org/GraphicsMagick)). I've opened a bug in the corresponding feedstock (https://github.com/conda-forge/graphicsmagick-feedstock/issues/34), so hopefully that will be fixed soon.
